### PR TITLE
Fix/cache time

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
     "vitest": "^3.1.4",
     "vite-plugin-dts": "^4.5.4",
     "vite-tsconfig-paths": "^5.1.4"
-  }
+  },
+  "packageManager": "yarn@4.9.1+sha512.f95ce356460e05be48d66401c1ae64ef84d163dd689964962c6888a9810865e39097a5e9de748876c2e0bf89b232d583c33982773e9903ae7a76257270986538"
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,5 @@
     "vitest": "^3.1.4",
     "vite-plugin-dts": "^4.5.4",
     "vite-tsconfig-paths": "^5.1.4"
-  },
-  "packageManager": "yarn@4.9.1+sha512.f95ce356460e05be48d66401c1ae64ef84d163dd689964962c6888a9810865e39097a5e9de748876c2e0bf89b232d583c33982773e9903ae7a76257270986538"
+  }
 }

--- a/src/query/query-model.ts
+++ b/src/query/query-model.ts
@@ -36,7 +36,7 @@ export default abstract class ReactiveQueryModel<DATA, EVENTS = undefined> {
 
   protected get configs(): {
     maxRetryCall: number;
-    cachTime: number;
+    cacheTime: number | null;
     emptyVaultOnNewValue: boolean;
     initStore:
       | {
@@ -55,7 +55,7 @@ export default abstract class ReactiveQueryModel<DATA, EVENTS = undefined> {
       /**
        * Maximum amount of time before empty the store
        */
-      cachTime: this.DEFAULT_CACHE_TIME,
+      cacheTime: this.DEFAULT_CACHE_TIME,
 
       /**
        * Empty the vault when new data arrives
@@ -72,7 +72,7 @@ export default abstract class ReactiveQueryModel<DATA, EVENTS = undefined> {
   constructor() {
     this.store = createVault({
       emptyVaultOnNewValue: this.configs.emptyVaultOnNewValue,
-      initCacheTime: this.configs.cachTime,
+      initCacheTime: this.configs.cacheTime,
       initalKey: this.configs.initStore?.key,
       initialValue: this.configs.initStore?.value,
       initStaleTime: this.configs.initStore?.staleTime,

--- a/src/store/query/store-methods.ts
+++ b/src/store/query/store-methods.ts
@@ -47,13 +47,16 @@ export function invalidateKey<T>(
 
 export function setData<T>(
   store$: BehaviorSubject<{ [key: string]: BaseReactiveStore<T> }>,
+  emptyVaultOnNewValue?: boolean,
 ): (data: T, key: string) => void {
   return (data: T, key: string) => {
     const currentStore = store$.getValue();
-    const updatedStore = {
-      ...currentStore,
-      [key]: { ...currentStore[key], data },
-    };
+    const updatedStore = emptyVaultOnNewValue
+      ? { [key]: { ...currentStore[key], data } }
+      : {
+          ...currentStore,
+          [key]: { ...currentStore[key], data },
+        };
     store$.next(updatedStore);
   };
 }

--- a/src/store/query/store.ts
+++ b/src/store/query/store.ts
@@ -28,9 +28,10 @@ export default function createVault<T, E = undefined, F = unknown>(
      */
     initStaleTime?: number;
     /**
+     * Time the store will be invalidated in. If null provided, the store will not be invalidated ever.
      * In miliseconds
      */
-    initCacheTime?: number;
+    initCacheTime?: number | null;
     /**
      * Empty the vault when new data arrives
      */
@@ -63,21 +64,23 @@ export default function createVault<T, E = undefined, F = unknown>(
   const DEFAULT_CACHE_TIME = 3 * 60 * 1000; // 3 minute
   // handle cache time
   const cacheTime = init?.initCacheTime || DEFAULT_CACHE_TIME;
-  setInterval(() => {
-    store$.next({
-      ...(init?.initalKey && init?.initialValue
-        ? {
-            [init.initalKey]: getInitStore(init.initialValue),
-          }
-        : {}),
-    });
-  }, cacheTime);
+  if (init?.initCacheTime !== null) {
+    setInterval(() => {
+      store$.next({
+        ...(init?.initalKey && init?.initialValue
+          ? {
+              [init.initalKey]: getInitStore(init.initialValue),
+            }
+          : {}),
+      });
+    }, cacheTime);
+  }
 
   return {
     store$: store$.asObservable(),
     invalidate: invalidate(store$),
     invalidateKey: invalidateKey(store$),
-    setData: setData(store$),
+    setData: setData(store$, init?.emptyVaultOnNewValue),
     setStore: setStore(store$),
     setIsFetched: setIsFetched(store$),
     setIsFetching: setIsFetching(store$),

--- a/src/test/unit/store/query/store.test.ts
+++ b/src/test/unit/store/query/store.test.ts
@@ -71,6 +71,7 @@ describe("createVault", () => {
             [key: string]: BaseReactiveStore<Data>;
           }>,
         );
+        console.log(store.store$);
         // ? Assert
         expect(data).toEqual({
           [newKey]: {
@@ -114,6 +115,42 @@ describe("createVault", () => {
             staled: false,
             error: undefined,
             lastFetchedTime: new Date().getTime(),
+            staleTime: undefined,
+            isFetched: true,
+            isFetching: false,
+          },
+        });
+        vi.useRealTimers();
+      });
+
+      it("Should not invalidate the store if the cache time is null", async () => {
+        // * Arrange
+        const fakeCurrentDate = new Date();
+        vi.useFakeTimers();
+        vi.setSystemTime(fakeCurrentDate);
+        const store = createVault({
+          initalKey: "test",
+          initialValue: { name: "test" },
+          initCacheTime: null,
+        });
+        await firstValueFrom(
+          store.store$ as Observable<{
+            [key: string]: BaseReactiveStore<Data>;
+          }>,
+        );
+        vi.advanceTimersToNextTimer();
+        const data = await lastValueFrom(
+          store.store$.pipe(take(1)) as Observable<{
+            [key: string]: BaseReactiveStore<Data>;
+          }>,
+        );
+        expect(data).toEqual({
+          test: {
+            data: { name: "test" },
+            isLoading: false,
+            staled: false,
+            error: undefined,
+            lastFetchedTime: fakeCurrentDate.getTime(),
             staleTime: undefined,
             isFetched: true,
             isFetching: false,

--- a/src/test/unit/store/query/store.test.ts
+++ b/src/test/unit/store/query/store.test.ts
@@ -71,7 +71,6 @@ describe("createVault", () => {
             [key: string]: BaseReactiveStore<Data>;
           }>,
         );
-        console.log(store.store$);
         // ? Assert
         expect(data).toEqual({
           [newKey]: {


### PR DESCRIPTION
- Add possibility to provide cacheTime as null, which means cached stores won't be invalidated
- Fix bug with not deleting old stores in vault on calling **model.setData**. For deleting other stores new param passed.
- Fix typo